### PR TITLE
Use make module instead of command

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,9 +72,8 @@
     - singularity_installed_version.rc == 1
 
 - name: singularity | compile the Singularity binary | make
-  command: make -C builddir
-  args:
-    chdir: "{{ golang_install_dir }}/src/github.com/sylabs/singularity"
+  make:
+    chdir: "{{ golang_install_dir }}/src/github.com/sylabs/singularity/builddir"
   environment:
     PATH: '{{ golang_install_dir }}/bin:{{ ansible_env.PATH }}'
     GOROOT: '{{ golang_install_dir }}'
@@ -84,9 +83,9 @@
     - singularity_installed_version.rc == 1
 
 - name: singularity | compile the Singularity binary | make install
-  command: make -C builddir install
-  args:
-    chdir: "{{ golang_install_dir }}/src/github.com/sylabs/singularity"
+  make:
+    target: install
+    chdir: "{{ golang_install_dir }}/src/github.com/sylabs/singularity/builddir"
   environment:
     PATH: '{{ golang_install_dir }}/bin:{{ ansible_env.PATH }}'
     GOROOT: '{{ golang_install_dir }}'


### PR DESCRIPTION
Ansible has `make` module to use a Makefile. It is available on Ansible 2.1 or later.

**NOTE**
The conditional check is required even if use `make` module since some operations of the Makefile of Singularity are performed with or without build artifacts.

## Change

- Use `make` module instead of `command`