### PR TITLE
Enhance vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,9 +40,12 @@ Vagrant.configure("2") do |config|
 
       vms.vm.network :private_network, ip: box[:ip]
 
-      vms.vm.provision :ansible do |ansible|
-        ansible.playbook = "tests/vagrant.yml"
-        ansible.verbose = "vv"
+      if box[:name] == boxes.last[:name]
+        vms.vm.provision :ansible do |ansible|
+          ansible.playbook = "tests/vagrant.yml"
+          ansible.verbose = "vv"
+          ansible.limit = "all"
+        end
       end
     end
   end

--- a/tests/vagrant.yml
+++ b/tests/vagrant.yml
@@ -11,3 +11,5 @@
       when: ansible_os_family == "Debian"
   roles:
     - ../../
+  vars:
+    golang_gopath: /opt/go/packages

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -8,3 +8,4 @@ singularity_software_base:
   - squashfs-tools
   - libseccomp-dev
   - pkg-config
+  - git


### PR DESCRIPTION
fix #10 

## Changes

- Ansible provisioner will run once after all VMs are booted.
  - This is a trick written in https://www.vagrantup.com/docs/provisioning/ansible.html#tips-and-tricks

## Fix

- Add `git` to the dependencies of Debian platform